### PR TITLE
Feature/draft 4769 rename modular content to linked items

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ List<Cafe> cafes = response.getItems();
 
 1. Make sure that your model extends the `ContentItem` class.
 2. Create public fields with an `ElementMapping` decorator. This will make sure that the value from your field is mapped to the content item element.
-3. Based on the type of field, choose the proper element type. Supported element types include: `AssetsElement`, `ContentElement`, `DateTimeElement`, `ModularContentElement`, `MultipleChoiceElement`, `NumberElement`, `RichTextElement`, `TaxonomyElement`, `TextElement` and `UrlSlugElement`.
+3. Based on the type of field, choose the proper element type. Supported element types include: `AssetsElement`, `ContentElement`, `DateTimeElement`, `LinkedItemsElement`, `MultipleChoiceElement`, `NumberElement`, `RichTextElement`, `TaxonomyElement`, `TextElement` and `UrlSlugElement`.
 
 The following example shows a typical class with different types of elements:
 

--- a/delivery-core/src/main/java/com/kenticocloud/delivery_core/elements/LinkedItemsElement.java
+++ b/delivery-core/src/main/java/com/kenticocloud/delivery_core/elements/LinkedItemsElement.java
@@ -16,24 +16,24 @@ import com.kenticocloud.delivery_core.interfaces.item.item.IContentItem;
 
 import java.util.ArrayList;
 
-public class ModularContentElement<TItem extends IContentItem> extends ContentElement<ArrayList<TItem>> {
+public class LinkedItemsElement<TItem extends IContentItem> extends ContentElement<ArrayList<TItem>> {
     private ArrayList<TItem> value;
 
-    public ModularContentElement(
+    public LinkedItemsElement(
             ObjectMapper objectMapper,
             String name,
             String codename,
             String type,
             JsonNode value,
             ArrayList<TItem> items
-    ){
+    ) {
         super(objectMapper, name, codename, type);
 
         this.value = items;
     }
 
     @Override
-    public ArrayList<TItem> getValue(){
+    public ArrayList<TItem> getValue() {
         return this.value;
     }
 }

--- a/delivery-core/src/main/java/com/kenticocloud/delivery_core/models/item/ItemCloudResponses.java
+++ b/delivery-core/src/main/java/com/kenticocloud/delivery_core/models/item/ItemCloudResponses.java
@@ -25,7 +25,7 @@ public class ItemCloudResponses {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class DeliveryItemListingResponseRaw {
 
-        DeliveryItemListingResponseRaw(){
+        DeliveryItemListingResponseRaw() {
             // Mandatory constructor
         }
 
@@ -33,7 +33,7 @@ public class ItemCloudResponses {
         public List<ContentItemRaw> items;
 
         @JsonProperty("modular_content")
-        public JsonNode modularContent;
+        public JsonNode linkedItems;
 
         @JsonProperty("pagination")
         public CommonCloudResponses.PaginationRaw pagination;
@@ -43,7 +43,7 @@ public class ItemCloudResponses {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class DeliveryItemResponseRaw {
 
-        DeliveryItemResponseRaw(){
+        DeliveryItemResponseRaw() {
             // Mandatory constructor
         }
 
@@ -51,13 +51,13 @@ public class ItemCloudResponses {
         public ContentItemRaw item;
 
         @JsonProperty("modular_content")
-        public JsonNode modularContent;
+        public JsonNode linkedItems;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ContentItemRaw {
 
-        ContentItemRaw(){
+        ContentItemRaw() {
             // Mandatory constructor
         }
 
@@ -71,7 +71,7 @@ public class ItemCloudResponses {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ElementRaw {
 
-        ElementRaw(){
+        ElementRaw() {
             // Mandatory constructor
         }
 
@@ -88,7 +88,7 @@ public class ItemCloudResponses {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ContentItemSystemAttributesRaw {
 
-        ContentItemSystemAttributesRaw(){
+        ContentItemSystemAttributesRaw() {
             // Mandatory constructor
         }
 

--- a/delivery-core/src/main/java/com/kenticocloud/delivery_core/services/ResponseMapService.java
+++ b/delivery-core/src/main/java/com/kenticocloud/delivery_core/services/ResponseMapService.java
@@ -46,7 +46,7 @@ public final class ResponseMapService {
     private TaxonomyMapService taxonomyMapService;
     private ContentElementMapService contentElementMapService;
 
-    public ResponseMapService(IDeliveryConfig config){
+    public ResponseMapService(IDeliveryConfig config) {
         this.itemMapService = new ItemMapService(config, this.objectMapper);
         this.typeMapService = new TypeMapService(config, this.objectMapper);
         this.taxonomyMapService = new TaxonomyMapService(config, this.objectMapper);
@@ -54,18 +54,18 @@ public final class ResponseMapService {
         this.contentElementMapService = new ContentElementMapService(config, this.objectMapper);
     }
 
-    public<TItem extends IContentItem> DeliveryItemResponse<TItem> mapItemResponse(JSONObject cloudResponse) throws JSONException, IOException, IllegalAccessException {
+    public <TItem extends IContentItem> DeliveryItemResponse<TItem> mapItemResponse(JSONObject cloudResponse) throws JSONException, IOException, IllegalAccessException {
         ItemCloudResponses.DeliveryItemResponseRaw rawResponse = this.objectMapper.readValue(cloudResponse.toString(), ItemCloudResponses.DeliveryItemResponseRaw.class);
 
-        TItem item = this.itemMapService.mapItem(rawResponse.item, rawResponse.modularContent);
+        TItem item = this.itemMapService.mapItem(rawResponse.item, rawResponse.linkedItems);
 
         return new DeliveryItemResponse<>(item);
     }
 
-    public<TItem extends IContentItem> DeliveryItemListingResponse<TItem> mapItemListingResponse(JSONObject cloudResponse) throws JSONException, IOException, IllegalAccessException {
+    public <TItem extends IContentItem> DeliveryItemListingResponse<TItem> mapItemListingResponse(JSONObject cloudResponse) throws JSONException, IOException, IllegalAccessException {
         ItemCloudResponses.DeliveryItemListingResponseRaw rawResponse = this.objectMapper.readValue(cloudResponse.toString(), ItemCloudResponses.DeliveryItemListingResponseRaw.class);
 
-        List<TItem> items = this.itemMapService.mapItems(rawResponse.items, rawResponse.modularContent);
+        List<TItem> items = this.itemMapService.mapItems(rawResponse.items, rawResponse.linkedItems);
 
         return new DeliveryItemListingResponse<>(items, this.paginationMapService.mapPagination(rawResponse.pagination));
     }
@@ -89,7 +89,7 @@ public final class ResponseMapService {
     }
 
     public DeliveryTaxonomyResponse mapDeliveryTaxonomyResponse(JSONObject cloudResponse) throws IOException {
-        TaxonomyCloudResponses.TaxonomySingleResponseRaw rawResponse = this.objectMapper.readValue(cloudResponse.toString(), TaxonomyCloudResponses.TaxonomySingleResponseRaw .class);
+        TaxonomyCloudResponses.TaxonomySingleResponseRaw rawResponse = this.objectMapper.readValue(cloudResponse.toString(), TaxonomyCloudResponses.TaxonomySingleResponseRaw.class);
 
         return new DeliveryTaxonomyResponse(this.taxonomyMapService.mapTaxonomy(rawResponse.system, rawResponse.terms));
     }
@@ -101,4 +101,3 @@ public final class ResponseMapService {
         return new DeliveryContentTypeElementResponse(this.contentElementMapService.mapContentTypeElement(rawResponse));
     }
 }
-

--- a/sample-android-app/src/main/java/com/kenticocloud/delivery/sample/androidapp/data/models/Article.java
+++ b/sample-android-app/src/main/java/com/kenticocloud/delivery/sample/androidapp/data/models/Article.java
@@ -12,7 +12,7 @@ package com.kenticocloud.delivery.sample.androidapp.data.models;
 
 import com.kenticocloud.delivery_core.elements.AssetsElement;
 import com.kenticocloud.delivery_core.elements.DateTimeElement;
-import com.kenticocloud.delivery_core.elements.ModularContentElement;
+import com.kenticocloud.delivery_core.elements.LinkedItemsElement;
 import com.kenticocloud.delivery_core.elements.MultipleChoiceElement;
 import com.kenticocloud.delivery_core.elements.RichTextElement;
 import com.kenticocloud.delivery_core.elements.TaxonomyElement;
@@ -52,19 +52,19 @@ public final class Article extends ContentItem {
     public MultipleChoiceElement category;
 
     @ElementMapping("related_articles")
-    public ModularContentElement<Article> relatedArticles;
+    public LinkedItemsElement<Article> relatedArticles;
 
     public String getTitle() {
         return title.getValue();
     }
 
-    public String getTeaserImageUrl(){
+    public String getTeaserImageUrl() {
         AssetModel[] assets = this.teaserImage.getValue();
-        if (assets == null){
+        if (assets == null) {
             return null;
         }
 
-        if (assets.length == 0){
+        if (assets.length == 0) {
             return null;
         }
 
@@ -83,9 +83,15 @@ public final class Article extends ContentItem {
         return bodyCopy.getValue();
     }
 
-    public ElementsTaxonomyTerms[] getPersonas() { return personas.getValue(); }
+    public ElementsTaxonomyTerms[] getPersonas() {
+        return personas.getValue();
+    }
 
-    public MultipleChoiceOption[] getCategories() { return category.getValue(); }
+    public MultipleChoiceOption[] getCategories() {
+        return category.getValue();
+    }
 
-    public ArrayList<Article> getRelatedArticles() { return relatedArticles.getValue(); }
+    public ArrayList<Article> getRelatedArticles() {
+        return relatedArticles.getValue();
+    }
 }

--- a/sample-java-app/src/main/java/com/kenticocloud/delivery/sample/javaapp/models/Article.java
+++ b/sample-java-app/src/main/java/com/kenticocloud/delivery/sample/javaapp/models/Article.java
@@ -12,7 +12,7 @@ package com.kenticocloud.delivery.sample.javaapp.models;
 
 import com.kenticocloud.delivery_core.elements.AssetsElement;
 import com.kenticocloud.delivery_core.elements.DateTimeElement;
-import com.kenticocloud.delivery_core.elements.ModularContentElement;
+import com.kenticocloud.delivery_core.elements.LinkedItemsElement;
 import com.kenticocloud.delivery_core.elements.MultipleChoiceElement;
 import com.kenticocloud.delivery_core.elements.RichTextElement;
 import com.kenticocloud.delivery_core.elements.TaxonomyElement;
@@ -52,19 +52,19 @@ public final class Article extends ContentItem {
     public MultipleChoiceElement category;
 
     @ElementMapping("related_articles")
-    public ModularContentElement<Article> relatedArticles;
+    public LinkedItemsElement<Article> relatedArticles;
 
     public String getTitle() {
         return title.getValue();
     }
 
-    public String getTeaserImageUrl(){
+    public String getTeaserImageUrl() {
         AssetModel[] assets = this.teaserImage.getValue();
-        if (assets == null){
+        if (assets == null) {
             return null;
         }
 
-        if (assets.length == 0){
+        if (assets.length == 0) {
             return null;
         }
 
@@ -83,9 +83,15 @@ public final class Article extends ContentItem {
         return bodyCopy.getValue();
     }
 
-    public ElementsTaxonomyTerms[] getPersonas() { return personas.getValue(); }
+    public ElementsTaxonomyTerms[] getPersonas() {
+        return personas.getValue();
+    }
 
-    public MultipleChoiceOption[] getCategories() { return category.getValue(); }
+    public MultipleChoiceOption[] getCategories() {
+        return category.getValue();
+    }
 
-    public ArrayList<Article> getRelatedArticles() { return relatedArticles.getValue(); }
+    public ArrayList<Article> getRelatedArticles() {
+        return relatedArticles.getValue();
+    }
 }


### PR DESCRIPTION
### Motivation

Based on our vision regarding components and content items, we have to rename "Modular content element" to "Linked items element". From the Delivery SDK's point of view, it means that we have to rename everything (methods/properties/classes/..., including SDK documentation) that contains "modularContent" to "linkedItems".

Keep in mind, that the Delivery API responses will remain the same. They'll still contain "modular_content".

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docu has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

there should be no reference to "modular content" in the SDK's API. instead, there should be "linked items" everywhere

Fixes #41 