### PR TITLE
redone build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ android:
   - platform-tools
   - build-tools-26.0.2
   - android-26
-  - sys-img-armeabi-v7a-android-24
-  - extra-android-m2repository
-  - extra-google-m2repository
-  - extra-android-support
 
 script:
   - ".travis/build.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ android:
   - platform-tools
   - build-tools-26.0.2
   - android-26
+  - sys-img-armeabi-v7a-android-24
+  - extra-android-m2repository
+  - extra-google-m2repository
+  - extra-android-support
 
 script:
   - ".travis/build.sh"

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./gradlew clean build --stacktrace --debug
+./gradlew clean build

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./gradlew clean build
+./gradlew clean build --stacktrace --debug

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./gradlew build
+./gradlew clean build

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,11 +10,17 @@ To release a new version of the SDK you will need to follow the below guide:
 
 First, add the following lines to your local.properties within the Android SDK project:
 
-bintray.user=<Username>
-bintray.apikey=<API Key>
-bintray.gpg.password=<GPG Password>
+BINTRAY_USER=<bintray username>
+BINTRAY_KEY=<bintray api key>
+BINTRAY_GPG=<gpg key for signing artifacts in order to be transferred to maven>
+SONATYPE_USER=<sonatype user>
+SONATYPE_PASSWORD=<sonatype password>
+SDK_VERSION=<sdk version, i.e '3.0.2'>
+RX_VERSION_DESC=<description for what is included in this version to rx sdk>
+CORE_VERSION_DESC=<description for what is included in this version to core sdk>
+ANDROID_VERSION_DESC=<description for what is included in this version to android sdk>
 
-Username is a JCenter/ Bintray user that will be used for distributing the new version. The user must be part of the "Kentico" organization on JCenter before publishing. To request access to 'Kentico' organization please email developerscommunity@kentico.com.
+The Bintray user must be part of the "Kentico" organization on Bintray before publishing. To request access to 'Kentico' organization please email developerscommunity@kentico.com.
 
 API Key is the Bintray API key for this specific user, you can locate this from your user profile page.
 
@@ -22,22 +28,8 @@ GPG Password is used for the public/ private GPG keypair, this is used for signi
 
 Once you have the Bintray local properties in place you are ready to push a new version to Bintray. To do this do the following:
 
-1. Open the build.gradle for each library and iterate the library version however suits the change you made.
-2. Open 'Terminal' in Android Studio
-3. Type 'gradlew install' and wait for 'BUILD SUCCESSFUL'
-4. Type 'gradlew bintrayUpload' and wait for 'SUCCESSFUL' 
-5. Login to http://bintray.com (Jcenter)
-  a. Username: <Username>
-  b. Password: <Password>
-6. Click on the 'KenticoCloudDeliveryJavaRxSDK' repository (only visible when in the 'Kentico' organization)
-7. Confirm that the artifact versions were updated
+1. Open 'Terminal' in Android Studio
+2. Type 'gradlew clean build' and wait for 'BUILD SUCCESSFUL'
+3. Type 'gradlew build bintrayUpload' and wait for 'BUILD SUCCESSFUL'
   
-Now that the artifacts are up on JCenter we need to sync them over to Maven to ensure all developers will be able to have access to them. In order to do this you will need to ensure you have a Sonatype account setup and then request access to the Maven repo by sending us an email at developerscommunity@kentico.com. Once you have access to the repo you can do the following to commit your JCenter changes over to Maven
-
-1. Go back to Bintray and login
-2. Click on the name of an artifact (for example 'delivery-android')
-3. Click the 'Maven Central' tab
-4. Click 'Sync' ( this will synchronize the new version of the artifact to Maven )
-5. Repeat steps 2 – 4 for each of the artifacts
-
-Once you have completed these steps the artifacts should be fully up to date on both JCenter and Maven.
+The artifacts should be pushed to both Bintray (jcenter) and Maven. Maven will take a bit to show the new versions, but Bintray should be almost instantaneous

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,8 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.google.gms:google-services:3.1.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
-
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/delivery-android/build.gradle
+++ b/delivery-android/build.gradle
@@ -8,7 +8,21 @@
  *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
+    }
+}
+
 apply plugin: 'com.android.library'
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'maven-publish'
+
 
 android {
     compileSdkVersion 26
@@ -35,6 +49,21 @@ android {
     }
 }
 
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.amitshekhar.android:rx2-android-networking:1.0.0'
@@ -44,33 +73,98 @@ dependencies {
     }
 }
 
-ext {
-    bintrayRepo = 'kenticocloud-maven'
-    bintrayName = 'delivery-android'
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
-    publishedGroupId = 'com.kenticocloud'
-    libraryName = 'KenticoCloudDeliveryAndroid'
-    artifact = 'delivery-android'
 
-    libraryDescription = 'Android SDK for Kentico Cloud Delivery API'
-    siteUrl = 'https://kenticocloud.com/'
-    gitUrl = 'https://github.com/Kentico/KenticoCloudDeliveryJavaRxSDK.git'
 
-    libraryVersion = '3.0.0'
 
-    developerId = 'kentico_richards'
-    developerName = 'Richard Sustek'
-    developerEmail = 'ennspassion@gmail.com'
-
-    developerId = 'kentico_timothyf'
-    developerName = 'Timothy Fenton'
-    developerEmail = 'timothyf@kentico.com'
-
-    licenseName = 'MIT'
-    licenseUrl = 'https://github.com/Kentico/KenticoCloudDeliveryJavaRxSDK/blob/master/LICENSE.md'
-    allLicenses = ["MIT"]
+bintray {
+    user = properties.getProperty('BINTRAY_USER')
+    key = properties.getProperty('BINTRAY_KEY')
+    pkg {
+        repo = 'KenticoCloudDeliveryJavaRxSDK'
+        name = 'delivery-android'
+        userOrg = 'kentico'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
+        version {
+            name = properties.getProperty('SDK_VERSION')
+            desc = properties.getProperty('ANDROID_VERSION_DESC')
+            released  = new Date()
+            vcsTag = properties.getProperty('SDK_VERSION')
+            gpg {
+                sign = true //Determines whether to GPG sign the files. The default is false
+                passphrase = properties.getProperty('BINTRAY_GPG') //Optional. The passphrase for GPG signing'
+            }
+            mavenCentralSync {
+                sync = true
+                user = properties.getProperty('SONATYPE_USER')
+                password = properties.getProperty('SONATYPE_PASSWORD')
+            }
+        }
+    }
+    publications = ['BintrayPublication']
 }
 
-// Place it at the end of the file
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'
+
+// Create the pom configuration:
+def pomConfig = {
+    licenses {
+        license {
+            name "MIT"
+            url "https://github.com/Kentico/KenticoCloudDeliveryJavaRxSDK/blob/master/LICENSE.md"
+            distribution "repo"
+        }
+    }
+    developers {
+        developer {
+            id "kentico_richards"
+            name "Richard Sustek"
+            email "ennspassion@gmail.com"
+        }
+        developer {
+            id "kentico_timothyf"
+            name "Timothy Fenton"
+            email "timothyf@kentico.com"
+        }
+        developer {
+            id "kentico_jurajb"
+            name "Juraj Bielik"
+            email "jurajb@kentico.com"
+        }
+    }
+
+    scm {
+        url "git@github.com:Kentico/KenticoCloudDeliveryJavaRxSDK.git"
+    }
+}
+
+// Create the publication with the pom configuration:
+publishing {
+    publications {
+        BintrayPublication(MavenPublication){
+            artifact sourcesJar
+            artifact javadocJar
+            artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
+            groupId 'com.kenticocloud'
+            artifactId 'delivery-android'
+            version properties.getProperty('SDK_VERSION')
+            pom.withXml {
+                def dependenciesNode = asNode().appendNode('dependencies')
+                // Iterate over the compile dependencies (we don't want the test ones), adding a <dependency> node for each
+                configurations.compile.allDependencies.each {
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', it.group)
+                    dependencyNode.appendNode('artifactId', it.name)
+                    dependencyNode.appendNode('version', it.version)
+                }
+                def root = asNode()
+                root.appendNode('description', 'Android SDK for Kentico Cloud Delivery API')
+                root.appendNode('name', 'KenticoCloudDeliveryAndroid')
+                root.appendNode('url', 'https://kenticocloud.com/')
+                root.children().last() + pomConfig
+            }
+        }
+    }
+}

--- a/delivery-android/build.gradle
+++ b/delivery-android/build.gradle
@@ -149,7 +149,7 @@ publishing {
             artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
             groupId 'com.kenticocloud'
             artifactId 'delivery-android'
-            version properties.getProperty('SDK_VERSION')
+            version "3.0.2"
             pom.withXml {
                 def dependenciesNode = asNode().appendNode('dependencies')
                 // Iterate over the compile dependencies (we don't want the test ones), adding a <dependency> node for each

--- a/delivery-android/build.gradle
+++ b/delivery-android/build.gradle
@@ -76,8 +76,7 @@ dependencies {
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
-
-
+def latestVersion = properties.getProperty('SDK_VERSION')
 
 bintray {
     user = properties.getProperty('BINTRAY_USER')
@@ -89,7 +88,7 @@ bintray {
         licenses = ['MIT']
         vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
         version {
-            name = properties.getProperty('SDK_VERSION')
+            name = "$latestVersion"
             desc = properties.getProperty('ANDROID_VERSION_DESC')
             released  = new Date()
             vcsTag = properties.getProperty('SDK_VERSION')
@@ -149,7 +148,7 @@ publishing {
             artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
             groupId 'com.kenticocloud'
             artifactId 'delivery-android'
-            version "3.0.2"
+            version "$latestVersion"
             pom.withXml {
                 def dependenciesNode = asNode().appendNode('dependencies')
                 // Iterate over the compile dependencies (we don't want the test ones), adding a <dependency> node for each

--- a/delivery-core/build.gradle
+++ b/delivery-core/build.gradle
@@ -41,6 +41,8 @@ repositories {
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
+def latestVersion = properties.getProperty('SDK_VERSION')
+
 bintray {
     user = properties.getProperty('BINTRAY_USER')
     key = properties.getProperty('BINTRAY_KEY')
@@ -51,7 +53,7 @@ bintray {
         licenses = ['MIT']
         vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
         version {
-            name = properties.getProperty('SDK_VERSION')
+            name = "$latestVersion"
             desc = properties.getProperty('CORE_VERSION_DESC')
             released  = new Date()
             vcsTag = properties.getProperty('SDK_VERSION')
@@ -110,7 +112,7 @@ publishing {
             artifact javadocJar
             groupId 'com.kenticocloud'
             artifactId 'delivery-core'
-            version "3.0.2"
+            version "$latestVersion"
             pom.withXml {
                 def root = asNode()
                 root.appendNode('description', 'Java SDK Core for Kentico Cloud Delivery API')

--- a/delivery-core/build.gradle
+++ b/delivery-core/build.gradle
@@ -110,7 +110,7 @@ publishing {
             artifact javadocJar
             groupId 'com.kenticocloud'
             artifactId 'delivery-core'
-            version properties.getProperty('SDK_VERSION')
+            version "3.0.2"
             pom.withXml {
                 def root = asNode()
                 root.appendNode('description', 'Java SDK Core for Kentico Cloud Delivery API')

--- a/delivery-core/build.gradle
+++ b/delivery-core/build.gradle
@@ -7,8 +7,9 @@
  *
  *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 apply plugin: 'java'
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
 
 sourceCompatibility = "1.7"
 targetCompatibility = "1.7"
@@ -23,36 +24,100 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
 repositories {
+    jcenter()
 }
 
-ext {
-    bintrayRepo = 'kenticocloud-maven'
-    bintrayName = 'delivery-core'
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
-    publishedGroupId = 'com.kenticocloud'
-    libraryName = 'KenticoCloudDeliveryCore'
-    artifact = 'delivery-core'
-
-    libraryDescription = 'Core SDK for Kentico Cloud Delivery API'
-    siteUrl = 'https://kenticocloud.com/'
-    gitUrl = 'https://github.com/Kentico/KenticoCloudDeliveryJavaRxSDK.git'
-
-    libraryVersion = '3.0.0'
-
-    developerId = 'kentico_richards'
-    developerName = 'Richard Sustek'
-    developerEmail = 'ennspassion@gmail.com'
-
-    developerId = 'kentico_timothyf'
-    developerName = 'Timothy Fenton'
-    developerEmail = 'timothyf@kentico.com'
-
-    licenseName = 'MIT'
-    licenseUrl = 'https://github.com/Kentico/KenticoCloudDeliveryJavaRxSDK/blob/master/LICENSE.md'
-    allLicenses = ["MIT"]
+bintray {
+    user = properties.getProperty('BINTRAY_USER')
+    key = properties.getProperty('BINTRAY_KEY')
+    pkg {
+        repo = 'KenticoCloudDeliveryJavaRxSDK'
+        name = 'delivery-core'
+        userOrg = 'kentico'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
+        version {
+            name = properties.getProperty('SDK_VERSION')
+            desc = properties.getProperty('CORE_VERSION_DESC')
+            released  = new Date()
+            vcsTag = properties.getProperty('SDK_VERSION')
+            gpg {
+                sign = true //Determines whether to GPG sign the files. The default is false
+                passphrase = properties.getProperty('BINTRAY_GPG') //Optional. The passphrase for GPG signing'
+            }
+            mavenCentralSync {
+                sync = true
+                user = properties.getProperty('SONATYPE_USER')
+                password = properties.getProperty('SONATYPE_PASSWORD')
+            }
+        }
+    }
+    publications = ['BintrayPublication']
 }
 
-// Place it at the end of the file
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'
+// Create the pom configuration:
+def pomConfig = {
+    licenses {
+        license {
+            name "MIT"
+            url "https://github.com/Kentico/KenticoCloudDeliveryJavaRxSDK/blob/master/LICENSE.md"
+            distribution "repo"
+        }
+    }
+    developers {
+        developer {
+            id "kentico_richards"
+            name "Richard Sustek"
+            email "ennspassion@gmail.com"
+        }
+        developer {
+            id "kentico_timothyf"
+            name "Timothy Fenton"
+            email "timothyf@kentico.com"
+        }
+        developer {
+            id "kentico_jurajb"
+            name "Juraj Bielik"
+            email "jurajb@kentico.com"
+        }
+    }
+
+    scm {
+        url "git@github.com:Kentico/KenticoCloudDeliveryJavaRxSDK.git"
+    }
+}
+
+// Create the publication with the pom configuration:
+publishing {
+    publications {
+        BintrayPublication(MavenPublication) {
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+            groupId 'com.kenticocloud'
+            artifactId 'delivery-core'
+            version properties.getProperty('SDK_VERSION')
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description', 'Java SDK Core for Kentico Cloud Delivery API')
+                root.appendNode('name', 'KenticoCloudDeliveryCore')
+                root.appendNode('url', 'https://kenticocloud.com/')
+                root.children().last() + pomConfig
+            }
+        }
+    }
+}

--- a/delivery-rx/build.gradle
+++ b/delivery-rx/build.gradle
@@ -7,8 +7,9 @@
  *
  *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 apply plugin: 'java'
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
 
 sourceCompatibility = "1.7"
 targetCompatibility = "1.7"
@@ -20,35 +21,100 @@ dependencies {
     compile 'com.squareup.okhttp3:okhttp:3.9.0'
 }
 
-ext {
-    bintrayRepo = 'kenticocloud-maven'
-    bintrayName = 'delivery-rx'
-
-    publishedGroupId = 'com.kenticocloud'
-    libraryName = 'KenticoCloudDeliveryJava'
-    artifact = 'delivery-rx'
-
-    libraryDescription = 'Java SDK for Kentico Cloud Delivery API'
-    siteUrl = 'https://kenticocloud.com/'
-    gitUrl = 'https://github.com/Kentico/KenticoCloudDeliveryJavaRxSDK.git'
-
-    libraryVersion = '3.0.0'
-
-    developerId = 'kentico_richards'
-    developerName = 'Richard Sustek'
-    developerEmail = 'ennspassion@gmail.com'
-
-    developerId = 'kentico_timothyf'
-    developerName = 'Timothy Fenton'
-    developerEmail = 'timothyf@kentico.com'
-
-    licenseName = 'MIT'
-    licenseUrl = 'https://github.com/Kentico/KenticoCloudDeliveryJavaRxSDK/blob/master/LICENSE.md'
-    allLicenses = ["MIT"]
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
 }
 
-// Place it at the end of the file
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
 
+repositories {
+    jcenter()
+}
 
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
+
+bintray {
+    user = properties.getProperty('BINTRAY_USER')
+    key = properties.getProperty('BINTRAY_KEY')
+    pkg {
+        repo = 'KenticoCloudDeliveryJavaRxSDK'
+        name = 'delivery-rx'
+        userOrg = 'kentico'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
+        version {
+            name = properties.getProperty('SDK_VERSION')
+            desc = properties.getProperty('RX_VERSION_DESC')
+            released  = new Date()
+            vcsTag = properties.getProperty('SDK_VERSION')
+            gpg {
+                sign = true //Determines whether to GPG sign the files. The default is false
+                passphrase = properties.getProperty('BINTRAY_GPG') //Optional. The passphrase for GPG signing'
+            }
+            mavenCentralSync {
+                sync = true
+                user = properties.getProperty('SONATYPE_USER')
+                password = properties.getProperty('SONATYPE_PASSWORD')
+            }
+        }
+    }
+    publications = ['BintrayPublication']
+}
+
+// Create the pom configuration:
+def pomConfig = {
+    licenses {
+        license {
+            name "MIT"
+            url "https://github.com/Kentico/KenticoCloudDeliveryJavaRxSDK/blob/master/LICENSE.md"
+            distribution "repo"
+        }
+    }
+    developers {
+        developer {
+            id "kentico_richards"
+            name "Richard Sustek"
+            email "ennspassion@gmail.com"
+        }
+        developer {
+            id "kentico_timothyf"
+            name "Timothy Fenton"
+            email "timothyf@kentico.com"
+        }
+        developer {
+            id "kentico_jurajb"
+            name "Juraj Bielik"
+            email "jurajb@kentico.com"
+        }
+    }
+
+    scm {
+        url "git@github.com:Kentico/KenticoCloudDeliveryJavaRxSDK.git"
+    }
+}
+
+// Create the publication with the pom configuration:
+publishing {
+    publications {
+        BintrayPublication(MavenPublication) {
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+            groupId 'com.kenticocloud'
+            artifactId 'delivery-rx'
+            version properties.getProperty('SDK_VERSION')
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description', 'Java RX SDK for Kentico Cloud Delivery API')
+                root.appendNode('name', 'KenticoCloudDeliveryJavaRX')
+                root.appendNode('url', 'https://kenticocloud.com/')
+                root.children().last() + pomConfig
+            }
+        }
+    }
+}

--- a/delivery-rx/build.gradle
+++ b/delivery-rx/build.gradle
@@ -107,7 +107,7 @@ publishing {
             artifact javadocJar
             groupId 'com.kenticocloud'
             artifactId 'delivery-rx'
-            version properties.getProperty('SDK_VERSION')
+            version "3.0.2"
             pom.withXml {
                 def root = asNode()
                 root.appendNode('description', 'Java RX SDK for Kentico Cloud Delivery API')

--- a/delivery-rx/build.gradle
+++ b/delivery-rx/build.gradle
@@ -38,6 +38,8 @@ repositories {
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
+def latestVersion = properties.getProperty('SDK_VERSION')
+
 bintray {
     user = properties.getProperty('BINTRAY_USER')
     key = properties.getProperty('BINTRAY_KEY')
@@ -48,7 +50,7 @@ bintray {
         licenses = ['MIT']
         vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
         version {
-            name = properties.getProperty('SDK_VERSION')
+            name = "$latestVersion"
             desc = properties.getProperty('RX_VERSION_DESC')
             released  = new Date()
             vcsTag = properties.getProperty('SDK_VERSION')
@@ -107,7 +109,7 @@ publishing {
             artifact javadocJar
             groupId 'com.kenticocloud'
             artifactId 'delivery-rx'
-            version "3.0.2"
+            version "$latestVersion"
             pom.withXml {
                 def root = asNode()
                 root.appendNode('description', 'Java RX SDK for Kentico Cloud Delivery API')


### PR DESCRIPTION
Completely overhauled the build / release process for version updates. Now there are more properties to add in local.properties but you no longer have to use the web UI at all. Also we are no longer relying on an outdated plugin/script that someone wrote and has not updated. we are using the official bintray plugin for gradle

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docu has been updated (if applicable)
- [ ] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults